### PR TITLE
[Fix] 카카오/구글 로그인 redirectUri 화이트리스트 수정 (#235)

### DIFF
--- a/backend/auth/src/controllers/startGoogleLogin.controller.js
+++ b/backend/auth/src/controllers/startGoogleLogin.controller.js
@@ -7,8 +7,8 @@ const redisClient = createClient({
 });
 
 const ALLOWED_REDIRECT_URIS = [
-  "http://localhost:3000/login/callback",
-  "https://omechu.log8.kr/login/callback",
+  "http://localhost:3000/auth/callback/google",
+  "https://omechu.log8.kr/auth/callback/google",
 ];
 
 export const startGoogleLogin = async (req, res, next) => {

--- a/backend/auth/src/controllers/startKakaoLogin.controller.js
+++ b/backend/auth/src/controllers/startKakaoLogin.controller.js
@@ -7,8 +7,8 @@ const redisClient = createClient({
 });
 
 const ALLOWED_REDIRECT_URIS = [
-    "http://localhost:3000/login/callback",
-  "https://omechu.log8.kr/login/callback",
+  "http://localhost:3000/auth/callback/kakao",
+  "https://omechu.log8.kr/auth/callback/kakao",
 ];
 
 export const startKakaoLogin = async (req, res, next) => {


### PR DESCRIPTION
## #️⃣ Issue Number

#235

## 📝 요약(Summary)

- 카카오/구글 로그인 시 `Invalid redirectUri` 에러 수정
- 프론트엔드 콜백 경로(`/auth/callback/kakao`, `/auth/callback/google`)와 일치하도록 화이트리스트 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📷 스크린샷 (선택)

**변경 전:**
```javascript
const ALLOWED_REDIRECT_URIS = [
  "http://localhost:3000/login/callback",
  "https://omechu.log8.kr/login/callback",
];
```

**변경 후:**
```javascript
// startKakaoLogin.controller.js
const ALLOWED_REDIRECT_URIS = [
  "http://localhost:3000/auth/callback/kakao",
  "https://omechu.log8.kr/auth/callback/kakao",
];

// startGoogleLogin.controller.js
const ALLOWED_REDIRECT_URIS = [
  "http://localhost:3000/auth/callback/google",
  "https://omechu.log8.kr/auth/callback/google",
];
```